### PR TITLE
Dirty workaround for scope not getting cleaned up and generating errors (#218)

### DIFF
--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -126,6 +126,10 @@
           };
 
           ctrl.initListeners = function() {
+            if (!element) {
+              return;
+            }
+
             if (ctrl.options.immediateAngularModelUpdate) {
               ctrl.froalaEditor.events.on('keyup', function() {
                 scope.$evalAsync(ctrl.updateModelView);


### PR DESCRIPTION
The scope will still be kept alive for reasons unknown - but will not throw errors.